### PR TITLE
Add architectures stanza

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -10,6 +10,10 @@ description: |
 grade: stable
 confinement: classic
 
+architectures:
+  - build-on: amd64
+  - build-on: i386
+
 parts:
   vscode:
     plugin: dump
@@ -18,8 +22,6 @@ parts:
       # so fail the build on other architectures.
       - on amd64: https://go.microsoft.com/fwlink/?LinkID=760868
       - on i386: https://go.microsoft.com/fwlink/?LinkID=760680
-      - on arm64: fail
-      - on armhf: fail
     source-type: deb
     override-build: |
       ARCHITECTURE=$(dpkg --print-architecture)


### PR DESCRIPTION
Adding the architectures stanza which means we don't waste time building on unsupported architectures. See [this thread](https://forum.snapcraft.io/t/architectures/4972) for more details.