### PR TITLE
Update to include 'license: "MIT"' field

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,7 @@
 name: vscode
 version: latest
 version-script: cat $SNAPCRAFT_STAGE/version
+license: "MIT"
 summary: Code editing. Redefined.
 description: |
   Visual Studio Code is a new choice of tool that combines the


### PR DESCRIPTION
A quickie edit to be rid of the incorrect "proprietary" description on the snapcraft store.