### PR TITLE
Stage fcitx-frontend-gtk3 so that CJK IMEs function. Closes #28

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -46,6 +46,7 @@ parts:
       - dpkg
       - sed
     stage-packages:
+      - fcitx-frontend-gtk3
       - libasound2
       - libgconf2-4
       - libgtk-3-0


### PR DESCRIPTION
Staging `fcitx-frontend-gtk3` enables the use of CJK input methods.