### PR TITLE
Add desktop plug to vscode

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -66,6 +66,8 @@ apps:
   vscode:
     command: bin/electron-launch ${SNAP}/usr/share/code/bin/code
     desktop: usr/share/applications/code.desktop
+    plugs:
+      - desktop
 
   url-handler:
     command: bin/electron-launch ${SNAP}/usr/share/code/bin/code --open-url


### PR DESCRIPTION
This fixes the missing fonts in vscode after upgrading my desktop to
Ubuntu 18.10. This is possibly related to https://github.com/snapcrafters/vscode/issues/9.
Should fix https://github.com/snapcrafters/vscode/issues/9