### PR TITLE
Add the GNOME 3.26 backport PPA.

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -15,7 +15,18 @@ architectures:
   - build-on: i386
 
 parts:
+  gnome:
+    plugin: nil
+    build-packages:
+      - software-properties-common
+    override-pull: |
+      add-apt-repository -y ppa:ubuntu-desktop/gnome-3-26
+      apt -y update
+      apt -y upgrade
+
   vscode:
+    after:
+      - gnome
     plugin: dump
     source:
       # Visual Studio Code is only available for i386 (x86) and amd64 (x86_64),


### PR DESCRIPTION
This pull request enables the GNOME 3.26 PPA supported by the Ubuntu Desktop team. This fixes access to user fonts and also theme integration. Thanks @kenvandine!