### PR TITLE
Add wrapper

### DIFF
--- a/files/bin/wrapper
+++ b/files/bin/wrapper
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+# On Fedora $SNAP is under /var and there is some magic to map it to /snap.
+# We need to handle that case and reset $SNAP
+SNAP=$(echo $SNAP | sed -e "s|/var/lib/snapd||g")
+
+if [ "$SNAP_ARCH" == "amd64" ]; then
+  ARCH="x86_64-linux-gnu"
+elif [ "$SNAP_ARCH" == "armhf" ]; then
+  ARCH="arm-linux-gnueabihf"
+elif [ "$SNAP_ARCH" == "arm64" ]; then
+  ARCH="aarch64-linux-gnu"
+else
+  ARCH="$SNAP_ARCH-linux-gnu"
+fi
+
+export XDG_CACHE_HOME=$SNAP_USER_COMMON/.cache
+if [[ -d $SNAP_USER_DATA/.cache && ! -e $XDG_CACHE_HOME ]]; then
+  # the .cache directory used to be stored under $SNAP_USER_DATA, migrate it
+  mv $SNAP_USER_DATA/.cache $SNAP_USER_COMMON/
+fi
+mkdir -p $XDG_CACHE_HOME
+
+# Gdk-pixbuf loaders
+export GDK_PIXBUF_MODULE_FILE=$XDG_CACHE_HOME/gdk-pixbuf-loaders.cache
+export GDK_PIXBUF_MODULEDIR=$SNAP/usr/lib/$ARCH/gdk-pixbuf-2.0/2.10.0/loaders
+if [ -f $SNAP/usr/lib/$ARCH/gdk-pixbuf-2.0/gdk-pixbuf-query-loaders ]; then
+  $SNAP/usr/lib/$ARCH/gdk-pixbuf-2.0/gdk-pixbuf-query-loaders > $GDK_PIXBUF_MODULE_FILE
+fi
+
+# Create $XDG_RUNTIME_DIR if not exists (to be removed when https://pad.lv/1656340 is fixed)
+[ -n "$XDG_RUNTIME_DIR" ] && mkdir -p $XDG_RUNTIME_DIR -m 700
+
+exec "$@"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -69,22 +69,25 @@ parts:
       - libsecret-1-0
       - libxss1
       - libxtst6
+  wrapper:
+    after:
+      - vscode
+    plugin: dump
+    source: files/
 
 apps:
   vscode:
-    command: usr/share/code/bin/code
+    command: bin/wrapper $SNAP/usr/share/code/bin/code
     desktop: usr/share/applications/code.desktop
     environment:
       # Fallback to XWayland if running in a Wayland session.
       DISABLE_WAYLAND: 1
-      GDK_PIXBUF_MODULEDIR: $SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/gdk-pixbuf-2.0/2.10.0/loaders
       GSETTINGS_SCHEMA_DIR: $SNAP/usr/share/glib-2.0/schemas
 
   url-handler:
-    command: usr/share/code/bin/code --open-url
+    command: bin/wrapper $SNAP/usr/share/code/bin/code --open-url
     desktop: usr/share/applications/code-url-handler.desktop
     environment:
       # Fallback to XWayland if running in a Wayland session.
       DISABLE_WAYLAND: 1
-      GDK_PIXBUF_MODULEDIR: $SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/gdk-pixbuf-2.0/2.10.0/loaders
       GSETTINGS_SCHEMA_DIR: $SNAP/usr/share/glib-2.0/schemas

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -57,8 +57,11 @@ parts:
       - sed
     stage-packages:
       - fcitx-frontend-gtk3
+      - gvfs-libs
       - libasound2
-      - libgconf2-4
+      - libgconf-2-4
+      - libglib2.0-bin
+      - libgnome-keyring0
       - libgtk-3-0
       - libnotify4
       - libnspr4
@@ -68,6 +71,7 @@ parts:
       - libsecret-1-0
       - libxss1
       - libxtst6
+      - zlib1g
   wrapper:
     after:
       - vscode

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -72,6 +72,13 @@ parts:
       - libxss1
       - libxtst6
       - zlib1g
+    prime:
+      - -usr/share/doc
+      - -usr/share/fonts
+      - -usr/share/icons
+      - -usr/share/lintian
+      - -usr/share/man
+
   wrapper:
     after:
       - vscode

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -22,7 +22,6 @@ parts:
     override-pull: |
       add-apt-repository -y ppa:ubuntu-desktop/gnome-3-26
       apt -y update
-      apt -y upgrade
 
   vscode:
     after:


### PR DESCRIPTION
The pull request adds the wrapper back to fix permission errors at launch. GDK PixBuf module caches is built and a fix for Fedora is included. All required libraries are now stages and some unneeded files are removed from the snap.